### PR TITLE
Add client option to override base url 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "national-rail-darwin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": " national rail's darwin soap based api",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
In order to run in client browser, API needed to be called over a no-cors proxy. The base URL needed to be changed to the proxy address but was hardcoded. This can now be changed in the constructor options.

Hope this is ok with you - please let me know if there's a problem.